### PR TITLE
Add fd redirection in terraform scripts

### DIFF
--- a/terraform/get-script-parameters.sh
+++ b/terraform/get-script-parameters.sh
@@ -12,3 +12,10 @@ export STEP=$1; shift
 # Get all other command options
 # We use it to add other arguments to terraform commands
 export COMMAND_OPTIONS="$@"
+
+# When we run a `terraform output` command, we want the script to only display
+# the output of terraform, not the logs of the script.
+# For this we use fd redirection
+if [ "$STEP" = "output" ]; then
+    exec 3>&1 1>/dev/null # Save `value` of stdout in file descriptor 3 and redirect stdout to /dev/null
+fi

--- a/terraform/run-docker-compose-with-exit-code.sh
+++ b/terraform/run-docker-compose-with-exit-code.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-printf 'Launch Terraform script.\n'
-docker-compose pull
-docker-compose up \
-    --build \
-    --abort-on-container-exit \
-    --exit-code-from terraform \
-    terraform
+docker-compose pull --quiet
+printf '\n========================\n# Run Terraform script #\n========================\n\n'
+if true 2>/dev/null >&3; then # If the file descriptor 3 is open, we
+    exec 1>&3 3>&-            # restore value of stdout and close fd 3
+fi
+
+docker-compose run --rm terraform


### PR DESCRIPTION
# Description

We use bash file descriptor redirection to make the script quiet (not display anything) when we do a `terraform output` command 

# Submission Checklist

- [x] The code author has performed a self-review of the code.
- [x] The code author has performed a complete test of the code.
- [x] The documentation is up to date.
