### PR TITLE
Generalize shell script argument getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,14 @@ As we use Terraform to deploy our infrastructure. Our BASH deployment scripts ar
 
 ### Get BASH script parameters
 
-We always use the terraform step to launch as an argument of our BASH infrastructure script. So, the script `terraform/get-script-parameters.sh` checks if the argument exists and get arguments in the right variable.
+You can use the script `components/check-bash-parameters.sh` to parse scripts arguments. By default it will wait 1 argument and export it as `STEP` variable.
+All the others arguments are exported as `COMMAND_OPTIONS`.
+If you want to customize which parameters you want, you can export theses 2 variables:
+- `SCRIPT_PARAMS_VARIABLES`: A bash array containing variables names you want to export (ex: `export SCRIPT_PARAMS_VARIABLES=(PROVIDER REGION STEP)`).
+- `SCRIPT_PARAMS_USAGE`: The corresponding usage
 
-The variable `STEP` will be created with the first argument. For example its value will be `init`, `plan`, `apply` or `destroy`. You can use this variable as an argument for a terraform command.
-And the variable `COMMAND_OPTIONS` will be created with all other arguments.
+You can also use the script `terraform/get-script-parameters.sh`, it does the same but you have to have a `STEP` variable in your list and he will clean all script logs from stdout if the step you want to do is an `output`.
+This permit to parse the output of terraform in scripts without all the script logs poluate stdout
 
 * Requirements
 
@@ -135,7 +139,16 @@ Your script needs to have only one argument and to be a wrapper for a Terraform 
 * Usage
 
 ```
-# Check terraform script parameters
+# Check script parameters
+source ./bash-methods/terraform/get-script-parameters.sh
+```
+
+or
+
+```
+# Check custom script parameters
+export SCRIPT_PARAMS_VARIABLES=(PROVIDER REGION STEP)
+export SCRIPT_PARAMS_USAGE='<provider> <region> <step ex.init|plan|apply>'
 source ./bash-methods/terraform/get-script-parameters.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,13 +127,13 @@ If you want to customize which parameters you want, you can export theses 2 vari
 
 * Requirements
 
-Your script needs to have only one argument and to be a wrapper for a Terraform command.
+There is no specific requirements for this method.
 
 * Usage
 
 ```
 # Check script parameters
-source ./bash-methods/terraform/get-script-parameters.sh
+source ./bash-methods/components/check-bash-parameters.sh
 ```
 
 or
@@ -142,22 +142,36 @@ or
 # Check custom script parameters
 export SCRIPT_PARAMS_VARIABLES=(PROVIDER REGION STEP)
 export SCRIPT_PARAMS_USAGE='<provider> <region> <step ex.init|plan|apply>'
-source ./bash-methods/terraform/get-script-parameters.sh
+source ./bash-methods/components/check-bash-parameters.sh
 ```
-### Get parameters for Terraform script
-
-You can also use the script `terraform/get-script-parameters.sh`, it does the same but you must have a `STEP` variable in your list and it will clean all script logs from stdout if the step that you want to do is an `output`.
-It permits to parse the output of Terraform in scripts without all the script logs poluate stdout.
 
 ## Terraform
 
 As we use Terraform to deploy our infrastructure. Our BASH deployment scripts are almost all the same. We use BASH script before launching Terraform command to wrap the Terraform command and to modify configuration.
+We advise you to use both `terraform/get-script-parameters.sh` and `terraform/run-docker-compose-with-exit-code.sh` in the same script because 
+
+### Get parameters for Terraform script
+
+You can use the script `terraform/get-script-parameters.sh`, it does the same as the `components/check-bash-parameters.sh` script, but you must have a `STEP` variable in your list.
+It will clean all script logs from stdout if the step that you want to do is an `output`. It does that by redirecting stdout to `/dev/null` before the script can print anything. Then when you will launch the Terraform container with `terraform/run-docker-compose-with-exit-code.sh`, it will reactivate stdout to print the output.
+This permits to parse the output of Terraform in scripts without all the script logs poluate stdout.
+
+* Requirements
+
+If you use custom parameters for your bash script, you must have a `STEP` parameters in your list.
+
+* Usage
+
+```
+# Check Terraform parameters
+source ./bash-methods/terraform/get-script-parameters.sh
+```
 
 ### Launch Docker Compose and get exit code
 
-If, like us at DataDome, you use to launch Terraform in a Docker container to easily manage versions and isolate your processes. The method `terraform/run-docker-compose-with-exit-code.sh` will permit to you to launch your `docker-compose.yml` with the service `terraform`.
+If, like us at DataDome, you use to launch Terraform in a Docker container to easily manage versions and isolate your processes, the method `terraform/run-docker-compose-with-exit-code.sh` will permit you to launch your `docker-compose.yml` with the service `terraform`.
 
-This method will end your script with the status code of your Terraform command launched in the Docker container.
+This method will exit your script with the status code of your Terraform command launched in the Docker container.
 
 * Requirements
 

--- a/README.md
+++ b/README.md
@@ -117,20 +117,13 @@ And after that, create the `.env` file with secret values.
 source ./bash-methods/env-file/source-dot-env-file.sh
 ```
 
-## Terraform
-
-As we use Terraform to deploy our infrastructure. Our BASH deployment scripts are almost all the same. We use BASH script before launching Terraform command to wrap the Terraform command and to modify configuration.
-
-### Get BASH script parameters
+## Get BASH script parameters
 
 You can use the script `components/check-bash-parameters.sh` to parse scripts arguments. By default it will wait 1 argument and export it as `STEP` variable.
 All the others arguments are exported as `COMMAND_OPTIONS`.
 If you want to customize which parameters you want, you can export theses 2 variables:
 - `SCRIPT_PARAMS_VARIABLES`: A bash array containing variables names you want to export (ex: `export SCRIPT_PARAMS_VARIABLES=(PROVIDER REGION STEP)`).
 - `SCRIPT_PARAMS_USAGE`: The corresponding usage
-
-You can also use the script `terraform/get-script-parameters.sh`, it does the same but you must have a `STEP` variable in your list and it will clean all script logs from stdout if the step that you want to do is an `output`.
-It permits to parse the output of Terraform in scripts without all the script logs poluate stdout.
 
 * Requirements
 
@@ -151,6 +144,14 @@ export SCRIPT_PARAMS_VARIABLES=(PROVIDER REGION STEP)
 export SCRIPT_PARAMS_USAGE='<provider> <region> <step ex.init|plan|apply>'
 source ./bash-methods/terraform/get-script-parameters.sh
 ```
+### Get parameters for Terraform script
+
+You can also use the script `terraform/get-script-parameters.sh`, it does the same but you must have a `STEP` variable in your list and it will clean all script logs from stdout if the step that you want to do is an `output`.
+It permits to parse the output of Terraform in scripts without all the script logs poluate stdout.
+
+## Terraform
+
+As we use Terraform to deploy our infrastructure. Our BASH deployment scripts are almost all the same. We use BASH script before launching Terraform command to wrap the Terraform command and to modify configuration.
 
 ### Launch Docker Compose and get exit code
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If you want to customize which parameters you want, you can export theses 2 vari
 - `SCRIPT_PARAMS_VARIABLES`: A bash array containing variables names you want to export (ex: `export SCRIPT_PARAMS_VARIABLES=(PROVIDER REGION STEP)`).
 - `SCRIPT_PARAMS_USAGE`: The corresponding usage
 
-You can also use the script `terraform/get-script-parameters.sh`, it does the same but you have to have a `STEP` variable in your list and he will clean all script logs from stdout if the step you want to do is an `output`.
+You can also use the script `terraform/get-script-parameters.sh`, it does the same but you must have a `STEP` variable in your list and it will clean all script logs from stdout if the step that you want to do is an `output`.
 It permits to parse the output of Terraform in scripts without all the script logs poluate stdout.
 
 * Requirements

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you want to customize which parameters you want, you can export theses 2 vari
 - `SCRIPT_PARAMS_USAGE`: The corresponding usage
 
 You can also use the script `terraform/get-script-parameters.sh`, it does the same but you have to have a `STEP` variable in your list and he will clean all script logs from stdout if the step you want to do is an `output`.
-This permit to parse the output of terraform in scripts without all the script logs poluate stdout
+It permits to parse the output of Terraform in scripts without all the script logs poluate stdout.
 
 * Requirements
 

--- a/components/check-bash-parameters.sh
+++ b/components/check-bash-parameters.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-if [ -z "$SCRIPT_PARAMS_NUMBER" ]; then
-    SCRIPT_PARAMS_NUMBER=1
-fi
-
 if [ -z "$SCRIPT_PARAMS_VARIABLES" ]; then
     SCRIPT_PARAMS_VARIABLES=(STEP)
 fi
@@ -12,15 +8,11 @@ if [ -z "$SCRIPT_PARAMS_USAGE" ]; then
     SCRIPT_PARAMS_USAGE='<step ex.infrastructure|deployment|provisioning>'
 fi
 
-# Ensure that the array of varibales name is the same as the number of parameters
-if [ "${#SCRIPT_PARAMS_VARIABLES[@]}" != "$SCRIPT_PARAMS_NUMBER" ]; then
-    printf 'Error: length of `SCRIPT_PARAMS_VARIABLES` array is not the same as `SCRIPT_PARAMS_NUMBER`\n' >&2
-    exit 1
-fi
+script_params_number="${#SCRIPT_PARAMS_VARIABLES[@]}"
 
 # Check if number of provided parameters is correct
-if [[ "$#" < "$SCRIPT_PARAMS_NUMBER" ]]; then
-    printf 'Error: needs %s parameter(s) - called with %s parameter(s)\n' "$SCRIPT_PARAMS_NUMBER" "$#" >&2
+if [[ "$#" < "$script_params_number" ]]; then
+    printf 'Error: needs %s parameter(s) - called with %s parameter(s)\n' "$script_params_number" "$#" >&2
     printf 'Usage: %s %s\n' "$(basename "$0")" "$SCRIPT_PARAMS_USAGE" >&2
     exit 1
 fi

--- a/components/check-bash-parameters.sh
+++ b/components/check-bash-parameters.sh
@@ -1,17 +1,34 @@
 #!/bin/bash
 
-# Check if number of parameter is correct
-if [[ $# -lt 1 ]] ; then
-    printf 'Error: needs 1 parameter(s) - called with %s parameter(s)\n' "$#"
-    printf 'Usage: %s <step ex.infrastructure|deployment|provisioning>\n' "$(basename "$0")"
+if [ -z "$SCRIPT_PARAMS_NUMBER" ]; then
+    SCRIPT_PARAMS_NUMBER=1
+fi
+
+if [ -z "$SCRIPT_PARAMS_VARIABLES" ]; then
+    SCRIPT_PARAMS_VARIABLES=(STEP)
+fi
+
+if [ -z "$SCRIPT_PARAMS_USAGE" ]; then
+    SCRIPT_PARAMS_USAGE='<step ex.infrastructure|deployment|provisioning>'
+fi
+
+# Ensure that the array of varibales name is the same as the number of parameters
+if [ "${#SCRIPT_PARAMS_VARIABLES[@]}" != "$SCRIPT_PARAMS_NUMBER" ]; then
+    printf 'Error: length of `SCRIPT_PARAMS_VARIABLES` array is not the same as `SCRIPT_PARAMS_NUMBER`\n' >&2
     exit 1
 fi
 
-# Get step from parameter
-export STEP="${1}"
-
-# Exit if the step does not exist
-if [ ! -d "${STEP}" ]; then
-    printf 'The step %s does not exist.\n' "${STEP}"
-    exit 0
+# Check if number of provided parameters is correct
+if [[ "$#" < "$SCRIPT_PARAMS_NUMBER" ]]; then
+    printf 'Error: needs %s parameter(s) - called with %s parameter(s)\n' "$SCRIPT_PARAMS_NUMBER" "$#" >&2
+    printf 'Usage: %s %s\n' "$(basename "$0")" "$SCRIPT_PARAMS_USAGE" >&2
+    exit 1
 fi
+
+# Get variables from parameter
+for var in "${SCRIPT_PARAMS_VARIABLES[@]}"; do
+    export "$var"="${1}"; shift
+done
+
+# Export the command options variable
+export COMMAND_OPTIONS="$@"

--- a/terraform/get-script-parameters.sh
+++ b/terraform/get-script-parameters.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 
-# Check if number of parameter is correct
-if [[ $# -lt 1 ]] ; then
-    printf 'Error: needs at least 1 parameter(s) - called with %s parameter(s)\n' "$#"
-    printf 'Usage: %s <command ex.init|plan|apply>\n' "$(basename "$0")"
+BASEDIR=$(dirname "$(readlink -f -- "$0")")
+
+# If the user provided a custom set of variable and it doesn't contain the STEP variable,
+# we throw an error because we need it for Terraform scripts
+if [[ -n "$SCRIPT_PARAMS_VARIABLES" && ! "${SCRIPT_PARAMS_VARIABLES[@]}" =~ "STEP" ]]; then
+    printf "Error: STEP variable isn't in your \`SCRIPT_PARAMS_VARIABLES\`. It's needed by Terraform scripts\n" >&2
     exit 1
 fi
 
-# Get the first argument as the terraform step that will be launched
-export STEP=$1; shift
-# Get all other command options
-# We use it to add other arguments to terraform commands
-export COMMAND_OPTIONS="$@"
+source "$BASEDIR"/bash-methods/components/check-bash-parameters.sh
 
 # When we run a `terraform output` command, we want the script to only display
 # the output of terraform, not the logs of the script.


### PR DESCRIPTION
# Description

This will generalize the params and usage of our scripts, it stay compatible with existing script thanks to the default values, but now you can export theses 2 variables before sourcing it:
- `SCRIPT_PARAMS_VARIABLES`: A bash array containing variables names you want to export
- `SCRIPT_PARAMS_USAGE`: The corresponding usage

# Submission Checklist

- [x] The code author has performed a self-review of the code.
- [x] The code author has performed a complete test of the code.
- [x] The documentation is up to date.
