### PR TITLE
Fix comparison inside check parameters func

### DIFF
--- a/components/check-bash-parameters.sh
+++ b/components/check-bash-parameters.sh
@@ -11,7 +11,7 @@ fi
 script_params_number="${#SCRIPT_PARAMS_VARIABLES[@]}"
 
 # Check if number of provided parameters is correct
-if [[ "$#" < "$script_params_number" ]]; then
+if [ "$#" -lt "$script_params_number" ]; then
     printf 'Error: needs %s parameter(s) - called with %s parameter(s)\n' "$script_params_number" "$#" >&2
     printf 'Usage: %s %s\n' "$(basename "$0")" "$SCRIPT_PARAMS_USAGE" >&2
     exit 1


### PR DESCRIPTION
# Description

This fixes an issue where the comparison could be broken if you have
for example a number of required parameters of 2 and you provide
10 parameters, it would fail because
"<" comparison is doing string comparison in bash

# Submission Checklist

- [x] The code author has performed a self-review of the code.
- [x] The code author has performed a complete test of the code.
- [x] The documentation is up to date.
