### PR TITLE
fix: do not delete terraform lock file and fix SSH clone

### DIFF
--- a/makefiles/terraform.mk
+++ b/makefiles/terraform.mk
@@ -1,17 +1,19 @@
 TF_VERSION?=1.0.0
 
+SSH_KNOWN_HOSTS_FILE?=${HOME}/.ssh/known_hosts
+
 DOCKER_IMAGE?=hashicorp/terraform
 
 DOCKER_COMMAND?=docker run \
 				--rm \
 				--volume $(shell pwd):/deployment \
 				--volume ${SSH_AUTH_SOCK}:/ssh-agent \
+				--volume ${SSH_KNOWN_HOSTS_FILE}:/etc/ssh/ssh_known_hosts:ro \
 				--volume /etc/passwd:/etc/passwd:ro \
 				--workdir /deployment \
 				--user "$(shell id -u):$(shell id -g)" \
 				--env HOME=/deployment \
 				--env SSH_AUTH_SOCK=/ssh-agent \
-				--env GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
 				${DOCKER_OPTIONS} \
 				${DOCKER_IMAGE}:${TF_VERSION}
 

--- a/makefiles/terraform.mk
+++ b/makefiles/terraform.mk
@@ -11,6 +11,7 @@ DOCKER_COMMAND?=docker run \
 				--user "$(shell id -u):$(shell id -g)" \
 				--env HOME=/deployment \
 				--env SSH_AUTH_SOCK=/ssh-agent \
+				--env GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
 				${DOCKER_OPTIONS} \
 				${DOCKER_IMAGE}:${TF_VERSION}
 
@@ -36,6 +37,6 @@ shell:
 	@${DOCKER_COMMAND}
 
 clean:
-	@rm -rf .terraform*
+	@find . -name '.terraform*' -not -name '.terraform.lock.hcl' -exec rm -rf {} +
 
 .PHONY: all ssh-config init plan apply shell clean


### PR DESCRIPTION
# Description

There is two changes here:
- Avoid deleting `.terraform.lock.hcl` file when cleaning working dir
- Fix SSH cloning for Terraform modules by removing SSH host key checking

# Submission Checklist

- [x] The code author has performed a self-review of the code.
- [x] The code author has performed a complete test of the code.
- [x] The documentation is up to date.
