### PR TITLE
fix: make the vaultfiles modular

### DIFF
--- a/makefiles/ansible.mk
+++ b/makefiles/ansible.mk
@@ -9,6 +9,8 @@ PLAYBOOK_FILE?=./playbook.yml
 
 ANSIBLE_VERSION?=2.10.7
 
+VAULTFILES?= --vault-id .vaultfile_base
+
 DOCKER_IMAGE?=889652210640.dkr.ecr.eu-west-1.amazonaws.com/ansible
 
 DOCKER_COMMAND?=docker run \
@@ -34,11 +36,11 @@ install-roles: ssh-config
 	@${DOCKER_COMMAND} ansible-galaxy install --force --roles-path $(ROLES_PATH) -r $(REQUIREMENTS_FILES)
 
 check: ssh-config
-	@${DOCKER_COMMAND} ansible-playbook --diff --check ${o} $(PLAYBOOK_FILE)
+	@${DOCKER_COMMAND} ansible-playbook --diff --check ${VAULTFILES} ${o} $(PLAYBOOK_FILE)
 
 apply: ssh-config
 	@printf "\e[1;34mAnsible will apply changes, please don't forget to run your playbook in check mode.\nAre you sure you want to continue? [y/n]: \e[0m" && read ans && [ $${ans:-N} = y ]
-	@${DOCKER_COMMAND} ansible-playbook --diff ${o} $(PLAYBOOK_FILE)
+	@${DOCKER_COMMAND} ansible-playbook --diff ${VAULTFILES} ${o} $(PLAYBOOK_FILE)
 
 shell:
 	$(eval DOCKER_OPTIONS+=--interactive --tty --env HISTFILE=/dev/null --entrypoint /bin/sh)


### PR DESCRIPTION
This change makes the variable option for the vaultfiles more modular (because you can overload this variable if you assign it in the Makefile of the specific component)